### PR TITLE
Gif Memory Optimization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ struct RawFrame {
 struct Stack {
     count: usize,
     index: usize,
-    // what if we split these up?
     frames: Vec<RawFrame>,
     width: u32,
     height: u32,
@@ -141,18 +140,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn chunck_frame(
-    top: i32,
-    left: i32,
-    width: u32,
-    height: u32,
+    top: usize,
+    left: usize,
+    width: usize,
+    height: usize,
     pitch: usize,
     raw_pixels: &Vec<u8>,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let mut y = top as usize;
-    let local_pitch = width as usize * 4;
+    let mut y = top;
+    let local_pitch = width * 4;
     let mut pixel_square = Vec::new();
-    while y < (height + top as u32) as usize {
-        let start = y * pitch + left as usize * 4;
+    while y < height + top {
+        let start = y * pitch + left * 4;
         if start > raw_pixels.len() {
             return Err("bad start value".into());
         }
@@ -164,7 +163,7 @@ fn chunck_frame(
         pixel_square.extend_from_slice(pixel_row);
         y += 1;
     }
-    if pixel_square.len() % (width * 4) as usize != 0 || pixel_square.len() == 0 {
+    if pixel_square.len() % (width * 4) != 0 || pixel_square.len() == 0 {
         return Err("bad pixel square".into());
     }
     return Ok(pixel_square);
@@ -224,10 +223,10 @@ fn load_raw_frames(gif: &String) -> Result<(u32, u32, Vec<RawFrame>), Box<dyn st
                 );
                 //let pitch = frame.width as usize * 4;
                 let chunk = chunck_frame(
-                    y as i32,
-                    x as i32,
-                    width as u32,
-                    height as u32,
+                    y.into(),
+                    x.into(),
+                    width.into(),
+                    height.into(), 
                     pitch,
                     &pixels,
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,8 @@ impl Stack {
     }
 }
 
+const DIMENSION: usize = 30;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
 
@@ -189,7 +191,6 @@ fn load_raw_frames(gif: &String) -> Result<(u32, u32, Vec<RawFrame>), Box<dyn st
     decoder.set_color_output(gif::ColorOutput::RGBA);
     let mut decoder = decoder.read_info(file_in)?;
     let mut frames = Vec::new();
-    let dimension = 30;
     while let Some(frame) = decoder.read_next_frame()? {
         // print the line_length
         let delay = frame.delay as u32;
@@ -198,17 +199,17 @@ fn load_raw_frames(gif: &String) -> Result<(u32, u32, Vec<RawFrame>), Box<dyn st
         let pitch = frame.width as usize * 4;
         let mut squares = Vec::new();
 
-        for y in (0..frame.height).step_by(dimension) {
-            let height = if y + dimension as u16 > frame.height {
+        for y in (0..frame.height).step_by(DIMENSION) {
+            let height = if y + DIMENSION as u16 > frame.height {
                 frame.height - y
             } else {
-                dimension as u16
+                DIMENSION as u16
             };
-            for x in (0..frame.width).step_by(dimension) {
-                let width = if x + dimension as u16 > frame.width {
+            for x in (0..frame.width).step_by(DIMENSION) {
+                let width = if x + DIMENSION as u16 > frame.width {
                     frame.width - x
                 } else {
-                    dimension as u16
+                    DIMENSION as u16
                 };
                 let rect = Rect::new(
                     (frame.left + x) as i32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,12 +171,16 @@ fn chunck_frame(
 }
 
 fn check_square(frames: &Vec<RawFrame>, square: &Square) -> bool {
-    for previoud_frame in frames {
+    for previoud_frame in frames.iter().rev() {
         for previous_square in &previoud_frame.squares {
             if previous_square.rect == square.rect {
                 if previous_square.pixels == square.pixels {
                     return true;
                 }
+                return false;
+            }
+            // if the previous rect intersects with the current rect return false
+            if previous_square.rect.has_intersection(square.rect) {
                 return false;
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ impl Stack {
     }
 }
 
-const DIMENSION: usize = 30;
+const DIMENSION: usize = 32;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
@@ -193,6 +193,7 @@ fn load_raw_frames(gif: &String) -> Result<(u32, u32, Vec<RawFrame>), Box<dyn st
     let mut decoder = gif::DecodeOptions::new();
     // Configure the decoder such that it will expand the image to RGBA.
     decoder.set_color_output(gif::ColorOutput::RGBA);
+    let mut dup_count = 0;
     let mut decoder = decoder.read_info(file_in)?;
     let mut frames = Vec::new();
     while let Some(frame) = decoder.read_next_frame()? {
@@ -238,6 +239,7 @@ fn load_raw_frames(gif: &String) -> Result<(u32, u32, Vec<RawFrame>), Box<dyn st
                             pixels: chunk,
                         };
                         if check_square(&frames, &square) {
+                            dup_count += 1;
                             continue;
                         }
                         squares.push(square);
@@ -252,6 +254,7 @@ fn load_raw_frames(gif: &String) -> Result<(u32, u32, Vec<RawFrame>), Box<dyn st
 
         frames.push(RawFrame { delay, squares });
     }
+    println!("dup_count: {}", dup_count);
 
     let width = decoder.width();
     let height = decoder.height();

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ fn load_raw_frames(gif: &String) -> Result<(u32, u32, Vec<RawFrame>), Box<dyn st
 
         for y in 0..frame.height {
             let start = y as usize * pitch;
-            let end = (y as usize + 1) * pitch;
+            let end = start + pitch;
             if let Some(previous_pixels) = &previous_pixels {
                 if end < previous_pixels.len() {
                     if &pixels[start..end] == &previous_pixels[start..end] {

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-fn chunck_frame(
+fn chunk_frame(
     top: usize,
     left: usize,
     width: usize,
@@ -222,11 +222,11 @@ fn load_raw_frames(gif: &String) -> Result<(u32, u32, Vec<RawFrame>), Box<dyn st
                     height as u32,
                 );
                 //let pitch = frame.width as usize * 4;
-                let chunk = chunck_frame(
+                let chunk = chunk_frame(
                     y.into(),
                     x.into(),
                     width.into(),
-                    height.into(), 
+                    height.into(),
                     pitch,
                     &pixels,
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,6 @@ fn load_raw_frames(gif: &String) -> Result<(u32, u32, Vec<RawFrame>), Box<dyn st
     let mut decoder = gif::DecodeOptions::new();
     // Configure the decoder such that it will expand the image to RGBA.
     decoder.set_color_output(gif::ColorOutput::RGBA);
-    let mut dup_count = 0;
     let mut decoder = decoder.read_info(file_in)?;
     let mut frames = Vec::new();
     while let Some(frame) = decoder.read_next_frame()? {
@@ -238,7 +237,6 @@ fn load_raw_frames(gif: &String) -> Result<(u32, u32, Vec<RawFrame>), Box<dyn st
                             pixels: chunk,
                         };
                         if check_square(&frames, &square) {
-                            dup_count += 1;
                             continue;
                         }
                         squares.push(square);
@@ -253,7 +251,6 @@ fn load_raw_frames(gif: &String) -> Result<(u32, u32, Vec<RawFrame>), Box<dyn st
 
         frames.push(RawFrame { delay, squares });
     }
-    println!("dup_count: {}", dup_count);
 
     let width = decoder.width();
     let height = decoder.height();


### PR DESCRIPTION
Goal of this work is to reduce the memory consumption for large gifs by segmenting the frames into squares. If a square is the same as one from the a previous frame in the stack then there's no need to store and re-render it.